### PR TITLE
Add env variables for VSCode's dbt Power User

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,7 +168,7 @@ clovek_debata.csv
 data/*.db
 data/*.csv
 data/*.sql
-data/adk_wrapped.db.wal
+data/*.wal
 
 # MacOS
 .DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,23 @@
 {
-    "python.formatting.provider": "black"
+    "terminal.integrated.env.osx": {
+        // Environment variables for a dbt run outside of Docker/Meltano
+        // If you change them here, make sure to change them in terminal.integrated.env.linux/windows
+        "DBT_PROJECT_DIR": "${workspaceFolder}/greybox_conversion/transform",
+        "DBT_PROFILES_DIR": "${workspaceFolder}/greybox_conversion/transform/profiles/duckdb",
+        "DBT_DUCKDB_PATH": "${workspaceFolder}/data/adk_wrapped_full.db",
+        "MELTANO_PROJECT_ROOT": "${workspaceFolder}/greybox_conversion",
+        "TARGET_DUCKDB_FINAL_FILENAME": "adk_wrapped",
+        "TARGET_DUCKDB_INTERMEDIATE_FILENAME": "adk_wrapped_full",
+        "VSCODE_WORKSPACE": "${workspaceFolder}",
+    },
+    "terminal.integrated.env.windows": {
+        // Exact same as above
+        "DBT_PROJECT_DIR": "${workspaceFolder}/greybox_conversion/transform",
+        "DBT_PROFILES_DIR": "${workspaceFolder}/greybox_conversion/transform/profiles/duckdb",
+        "DBT_DUCKDB_PATH": "${workspaceFolder}/data/adk_wrapped_full.db",
+        "MELTANO_PROJECT_ROOT": "${workspaceFolder}/greybox_conversion",
+        "TARGET_DUCKDB_FINAL_FILENAME": "adk_wrapped",
+        "TARGET_DUCKDB_INTERMEDIATE_FILENAME": "adk_wrapped_full",
+        "VSCODE_WORKSPACE": "${workspaceFolder}",
+    },
 }

--- a/greybox_conversion/Dockerfile
+++ b/greybox_conversion/Dockerfile
@@ -1,5 +1,5 @@
 # registry.gitlab.com/meltano/meltano:latest is also available in GitLab Registry
-ARG MELTANO_IMAGE=meltano/meltano:latest
+ARG MELTANO_IMAGE=meltano/meltano:v3.4.0
 FROM $MELTANO_IMAGE
 
 WORKDIR /project

--- a/greybox_conversion/transform/profiles/duckdb/profiles.yml
+++ b/greybox_conversion/transform/profiles/duckdb/profiles.yml
@@ -10,7 +10,7 @@ meltano:
       path: "{{ env_var('DBT_DUCKDB_PATH') }}"
       threads: 8
       attach:
-        - path: "{{ env_var('MELTANO_PROJECT_ROOT') }}/output/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db"
+        - path: "{% if env_var('MELTANO_PROJECT_READONLY', 0) == 1 %}{{ env_var('MELTANO_PROJECT_ROOT') }}/output/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db{% else %}{{ env_var('VSCODE_WORKSPACE', '.') }}/data/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db{% endif %}"
           alias: final
     staging:
       <<: *dev

--- a/greybox_conversion/transform/profiles/duckdb/profiles.yml
+++ b/greybox_conversion/transform/profiles/duckdb/profiles.yml
@@ -15,7 +15,11 @@ meltano:
         # or it's not, in which case we'll use the data directory.
         #
         # The relevant variables are defined either in docker-compose.data_prep.yml or in .vscode/settings.json.
-        - path: "{% if env_var('MELTANO_PROJECT_READONLY', 0) == 1 %}{{ env_var('MELTANO_PROJECT_ROOT') }}/output/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db{% else %}{{ env_var('VSCODE_WORKSPACE', '.') }}/data/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db{% endif %}"
+        - path: "{% if env_var('MELTANO_PROJECT_READONLY', 0) == 1 %}\
+            {{ env_var('MELTANO_PROJECT_ROOT') }}/output/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db\
+            {% else %}\
+            {{ env_var('VSCODE_WORKSPACE', '.') }}/data/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db\
+            {% endif %}"
           alias: final
     staging:
       <<: *dev

--- a/greybox_conversion/transform/profiles/duckdb/profiles.yml
+++ b/greybox_conversion/transform/profiles/duckdb/profiles.yml
@@ -11,15 +11,15 @@ meltano:
       threads: 8
       attach:
         # What's going on here: Either MELTANO_PROJECT_READONLY is set by the Dockerfile, in which case we'll use
-        # the output directory (which is itself mounted to data/ outside of Docker)...
-        # or it's not, in which case we'll use the data directory.
+        # the output/ directory (which is itself mounted to data/ outside of Docker)...
+        # or it's not, in which case we're not in Docker and we'll use the data/ directory outside of Docker directly.
         #
         # The relevant variables are defined either in docker-compose.data_prep.yml or in .vscode/settings.json.
         - path: "{% if env_var('MELTANO_PROJECT_READONLY', 0) == 1 %}\
-            {{ env_var('MELTANO_PROJECT_ROOT') }}/output/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db\
+            {{ env_var('MELTANO_PROJECT_ROOT') }}/output\
             {% else %}\
-            {{ env_var('VSCODE_WORKSPACE', '.') }}/data/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db\
-            {% endif %}"
+            {{ env_var('VSCODE_WORKSPACE', '.') }}/data\
+            {% endif %}/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db"
           alias: final
     staging:
       <<: *dev

--- a/greybox_conversion/transform/profiles/duckdb/profiles.yml
+++ b/greybox_conversion/transform/profiles/duckdb/profiles.yml
@@ -10,6 +10,11 @@ meltano:
       path: "{{ env_var('DBT_DUCKDB_PATH') }}"
       threads: 8
       attach:
+        # What's going on here: Either MELTANO_PROJECT_READONLY is set by the Dockerfile, in which case we'll use
+        # the output directory (which is itself mounted to data/ outside of Docker)...
+        # or it's not, in which case we'll use the data directory.
+        #
+        # The relevant variables are defined either in docker-compose.data_prep.yml or in .vscode/settings.json.
         - path: "{% if env_var('MELTANO_PROJECT_READONLY', 0) == 1 %}{{ env_var('MELTANO_PROJECT_ROOT') }}/output/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db{% else %}{{ env_var('VSCODE_WORKSPACE', '.') }}/data/{{ env_var('TARGET_DUCKDB_FINAL_FILENAME', 'adk_wrapped') }}.db{% endif %}"
           alias: final
     staging:


### PR DESCRIPTION
This pull request adds the necessary environment variables for dbt Power User to work outside of Docker. The variables are added to the terminal configuration for macOS and Windows. Additionally, the dbt profiles and project directories are specified, along with the paths for the DuckDB database files.

(My apologies to the reviewer for the horrible conditional attach path; I don't think there's a way to make it more elegant.)