### PR TITLE
Update LPW achievement text based on count

### DIFF
--- a/greybox_conversion/transform/models/achievements/agg__lpw_count.sql
+++ b/greybox_conversion/transform/models/achievements/agg__lpw_count.sql
@@ -55,7 +55,12 @@ achievement_base as (
     select
         clovek_id,
         school_year,
-        count(*) as lpw_debate_count
+        count(*) as lpw_debate_count,
+        case
+            when count(*) between 1 and 2 then 'Vyhrál/a jsi pár debat navzdory všem předpokladům.'
+            when count(*) between 3 and 5 then 'Ukázal/a jsi konzistentní výkony v náročných debatách.'
+            when count(*) >= 6 then 'Prokázal/a jsi mimořádnou schopnost vyhrávat debaty proti týmům s vyšším skóre.'
+        end as achievement_description
     from lpw
     where is_low_point_win
     group by 1, 2
@@ -67,7 +72,7 @@ final as (
         school_year,
         {{ make_achievement_id('lpw_count') }},
         'Co je doma, to se počítá' as achievement_name,
-        'Vyhrál/a jsi alespoň jednu debatu, ve které měl soupeř dohromady více bodů než tvůj tým.' as achievement_description,
+        achievement_description,
         json_object(
             'lpw_debate_count', lpw_debate_count
         ) as achievement_data,


### PR DESCRIPTION
Related to #120

Implements dynamic achievement descriptions based on LPW (Low Point Win) counts in the `agg__lpw_count.sql` file.

- Introduces a case statement within the `achievement_base` CTE to assign different achievement descriptions based on the LPW count. This change allows for personalized feedback to users based on their performance in debates.
- For LPW counts of 1-2, sets the achievement description to acknowledge the user has won a few debates despite the odds.
- For LPW counts of 3-5, updates the description to highlight the user's consistent performance in challenging debates.
- For LPW counts of 6 or more, changes the description to celebrate the user's exceptional skill in winning debates against higher-scoring teams.
- Maintains the original structure of the SQL file while integrating the new conditional logic seamlessly into the existing codebase.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PiechZ/greybox_wrapped/issues/120?shareId=0fca8b0e-b93b-49a1-b5cd-1798cc5435f2).